### PR TITLE
Do not drift if the user has stopped moving the mouse

### DIFF
--- a/jquery.overscroll.js
+++ b/jquery.overscroll.js
@@ -49,6 +49,7 @@
             driftFrequency: 40, // 20 FPS
 			driftSequences: 22,
             driftDecay: 1.15,
+            driftTimeout: 250,
 			timeout: 400,
 			captureThreshold: 3,
 			wheelDelta: 20,
@@ -143,6 +144,7 @@
 		setPosition: function(event, position, index) {
 		    position.x = event.pageX;
 		    position.y = event.pageY;
+		    position.time = (new Date()).getTime();
 		    position.index = index;
 		    return position;
 		},
@@ -305,6 +307,10 @@
 
         // sends the overscrolled element into a drift
         drift: function(target, event, callback) {
+            // do not drift if the user has stopped dragging the element
+            if ((new Date()).getTime() - event.data.capture.time > o.constants.driftTimeout) {
+                return;
+            }
 
             o.normalizeEvent(event);
 


### PR DESCRIPTION
If you drag an Overscroll element then stop moving the mouse while _still_ holding down the left mouse button you do not expect the element to drift when you do release the left mouse button. Unfortunately this seems to happen about half the time I drag Overscroll elements around. It's especially noticeable/annoying if you drag the element very far very quick then immediately stop moving the mouse before releasing the left mouse button.

My change adds a driftTimeout constant which is used in the drift method to determine whether or not to drift based on how long it's been since event.data.capture was last updated.

Not the cleanest solution, but it works for me at least.
