### PR TITLE
Added restoration of original style information on removeOverscroll

### DIFF
--- a/jquery.overscroll.js
+++ b/jquery.overscroll.js
@@ -186,8 +186,13 @@
 
         remover: function (target, data) {
             return function () {
+                var origStyle = target.data(o.origStyleKey);
+                if (!origStyle) {
+                    target.removeAttr('style');
+                } else {
+                    target.attr('style', origStyle);
+                }
                 target
-                  .attr('style', target.data(o.origStyleKey))
                   .removeData(o.removerKey)
                   .removeData(o.origStyleKey)
                   .off(o.events.wheel, o.wheel)


### PR DESCRIPTION
Hi Azoff,

I needed to refresh overscroll due to size changes of the content and noticed, that the style attribute is completely removed on removeOverscroll. I changed this behavior to store the original style information in the elements data and the remover now restores this information.

Cheers,
Christoph
