### PR TITLE
Inject <body> node in case we're running in a test harness and don't yet have one.

### DIFF
--- a/jquery.overscroll.js
+++ b/jquery.overscroll.js
@@ -24,6 +24,9 @@
 	// The key used to bind-instance specific data to an object
 	var datakey = 'overscroll';
 
+    // create <body> node if there's not one present (e.g., for test runners)
+    if (dom.body === null) dom.documentElement.appendChild(dom.createElement('body'));
+
 	// runs feature detection for overscroll
 	var compat = {
 		animate: (function(){


### PR DESCRIPTION
In order to run specs using a test framework like jasmine, we need to inject a body node as overscroll.js expects one.
