### PR TITLE
Added settings.draggingTimeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jQuery.fn.overscroll.settings = {
     thumbOpacity:       0.7, // The default active opacity for the thumbs
     thumbThickness:     6,   // The thickness, in pixels, of the generated thumbs
     thumbTimeout:       400, // The amount of time to wait before fading out thumbs
-    draggingTimeout:    100, // The amount of time to wait before resetting the dragging flag back to false after stop dragging (useful when detecting dragging in onClick events
+    draggingTimeout:    100, // The amount of time to wait before resetting the dragging flag back to false after stop dragging (useful when detecting dragging in onClick events)
 }
 ```
 

--- a/dist/jquery.overscroll.js
+++ b/dist/jquery.overscroll.js
@@ -48,7 +48,7 @@
 		thumbOpacity:     0.7,
 		thumbThickness:   6,
 		thumbTimeout:     400,
-        draggingTimeout:  100,
+		draggingTimeout:  100,
 		wheelDelta:       20,
 		wheelTicks:       120
 	};


### PR DESCRIPTION
Useful so that the onClick events know they were dragged. without it the dragging flag is set back to false before the click event fires. E.G.

$overscroll =  $('#overscroll').overscroll();
$('#overscroll > a').on('click', function(event) {
           event.preventDefault();
           dragging = $overscroll.data('overscroll').dragging;
           console.log('Dragging: ' + dragging);
           if(!dragging) {
                console.log('Click');
           };
});
